### PR TITLE
Add deepcopy

### DIFF
--- a/scripts/generators/ecs_helpers.py
+++ b/scripts/generators/ecs_helpers.py
@@ -58,7 +58,7 @@ def fields_subset(subset, fields):
             retained_fields[key] = fields[key]
         elif isinstance(val['fields'], dict):
             # Copy the full field over so we get all the options, then replace the 'fields' with the right subset
-            retained_fields[key] = fields[key]
+            retained_fields[key] = deepcopy(fields[key])
             retained_fields[key]['fields'] = fields_subset(val['fields'], fields[key]['fields'])
     return retained_fields
 


### PR DESCRIPTION
There is an issue with reusable fields getting clobbered that I ran into while creating the subset for the event schema. Adding a deepcopy avoids the issue.

The reason I'm PRing this here is so we can have one main branch to point people too until this gets merged into ecs core. I can also open a PR to ecs core. Not sure if this branch is eventually going in there.